### PR TITLE
Add progressive enhancement for mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Effective Carnival</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="no-js">
+  <header class="site-header">
+    <div class="branding">
+      <a href="#" class="logo">Effective Carnival</a>
+      <p class="tagline">An accessible navigation demo</p>
+    </div>
+    <button class="nav-toggle" type="button" aria-expanded="true" aria-controls="primary-navigation">
+      <span class="toggle-label">Menu</span>
+      <span class="toggle-icon" aria-hidden="true"></span>
+    </button>
+    <nav id="primary-navigation" class="primary-nav" data-open="true" aria-label="Primary navigation" aria-hidden="false">
+      <ul>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">About</a></li>
+        <li><a href="#">Schedule</a></li>
+        <li><a href="#">Tickets</a></li>
+        <li><a href="#">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="content">
+    <h1>Welcome to Effective Carnival</h1>
+    <p>
+      This example showcases a navigation menu that remains accessible without JavaScript while
+      gracefully enhancing behaviour when scripting is available.
+    </p>
+    <p>
+      Resize the browser window below 900px wide to view the mobile layout. With JavaScript
+      enabled, the menu collapses into a toggle that slides in and out. When JavaScript is
+      disabled, the links stay visible so visitors can always reach every page.
+    </p>
+  </main>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,54 @@
+(function () {
+  const body = document.body;
+  body.classList.remove('no-js');
+  body.classList.add('has-js');
+
+  const nav = document.querySelector('.primary-nav');
+  const toggle = document.querySelector('.nav-toggle');
+
+  if (!nav || !toggle) {
+    return;
+  }
+
+  const closeMenu = () => {
+    nav.dataset.open = 'false';
+    nav.setAttribute('aria-hidden', 'true');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.classList.remove('is-active');
+  };
+
+  const openMenu = (activateToggle = true) => {
+    nav.dataset.open = 'true';
+    nav.setAttribute('aria-hidden', 'false');
+    toggle.setAttribute('aria-expanded', 'true');
+
+    if (activateToggle && window.innerWidth <= 900) {
+      toggle.classList.add('is-active');
+    } else {
+      toggle.classList.remove('is-active');
+    }
+  };
+
+  if (window.innerWidth > 900) {
+    openMenu(false);
+  } else {
+    closeMenu();
+  }
+
+  toggle.addEventListener('click', () => {
+    const isOpen = nav.dataset.open === 'true';
+    if (isOpen) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 900) {
+      openMenu(false);
+    } else if (!toggle.classList.contains('is-active')) {
+      closeMenu();
+    }
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,180 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  color: #222;
+  background: #f4f4f8;
+  min-height: 100vh;
+}
+
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
+  background: #ffffff;
+  position: relative;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-decoration: none;
+  color: #2a48a5;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.nav-toggle {
+  position: relative;
+  border: 0;
+  border-radius: 999px;
+  background: #2a48a5;
+  color: #fff;
+  font-size: 1rem;
+  padding: 0.65rem 1rem 0.65rem 2.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  display: none;
+}
+
+.nav-toggle:focus-visible {
+  outline: 3px solid rgba(42, 72, 165, 0.4);
+  outline-offset: 4px;
+}
+
+.nav-toggle:hover {
+  background: #1d3477;
+}
+
+.toggle-icon {
+  position: absolute;
+  inset: 50% auto auto 1rem;
+  width: 1.5rem;
+  height: 2px;
+  background: currentColor;
+  display: inline-block;
+  transform: translateY(-50%);
+  box-shadow: 0 -6px 0 0 currentColor, 0 6px 0 0 currentColor;
+}
+
+.primary-nav {
+  margin: 0;
+  padding: 0;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition: opacity 0.25s ease, visibility 0.25s ease, transform 0.25s ease;
+}
+
+.primary-nav ul {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  position: relative;
+}
+
+.primary-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.3rem;
+  width: 100%;
+  height: 2px;
+  background: #2a48a5;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.primary-nav a:focus-visible::after,
+.primary-nav a:hover::after {
+  transform: scaleX(1);
+}
+
+.content {
+  padding: clamp(1.5rem, 4vw, 4rem);
+  max-width: 60rem;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+  .site-header {
+    align-items: flex-start;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .primary-nav {
+    position: absolute;
+    top: calc(100% - 0.25rem);
+    right: clamp(1.5rem, 4vw, 3rem);
+    left: clamp(1.5rem, 4vw, 3rem);
+    padding: 1.25rem;
+    background: #ffffff;
+    border-radius: 0.75rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .primary-nav ul {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .primary-nav a {
+    font-size: 1.1rem;
+  }
+
+  /* With no JavaScript we keep the navigation visible for accessibility */
+  .primary-nav[data-open="true"] {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .has-js .primary-nav[data-open="false"] {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    pointer-events: none;
+  }
+
+  .has-js .primary-nav[data-open="true"] {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add a demo page with navigation markup to showcase the behaviour
- update the mobile styles so `.primary-nav` stays visible by default and only hides when the body has the `has-js` class
- initialise the script by toggling the `has-js` class and wiring the menu toggle for progressive enhancement

## Testing
- Manual verification: resized to <900px and removed `has-js` class to confirm navigation links stay visible without JavaScript


------
https://chatgpt.com/codex/tasks/task_e_68cb666b2ce08321b56e11418ab0d05d