### PR TITLE
Ensure nav remains visible without JavaScript

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,11 @@
 (function () {
   const body = document.body;
+
+  if (!body) {
+    return;
+  }
+
+  // Flag scripting support so CSS can collapse the menu only after JS boots.
   body.classList.remove('no-js');
   body.classList.add('has-js');
 
@@ -8,6 +14,10 @@
 
   if (!nav || !toggle) {
     return;
+  }
+
+  if (!nav.dataset.open) {
+    nav.dataset.open = 'true';
   }
 
   const closeMenu = () => {

--- a/styles.css
+++ b/styles.css
@@ -157,13 +157,7 @@ body {
     font-size: 1.1rem;
   }
 
-  /* With no JavaScript we keep the navigation visible for accessibility */
-  .primary-nav[data-open="true"] {
-    opacity: 1;
-    visibility: visible;
-    transform: translateY(0);
-  }
-
+  /* Hide the menu only when scripting is active */
   .has-js .primary-nav[data-open="false"] {
     opacity: 0;
     visibility: hidden;


### PR DESCRIPTION
## Summary
- keep the mobile navigation visible by default and only hide it when a `.has-js` class is present
- add a JavaScript hook that flags scripting support before wiring listeners and ensures the menu dataset has an initial state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cba42ade04832192eff110512c4cb4