### PR TITLE
Fix TypeScript configuration and string literal issues

### DIFF
--- a/cukaipal-mobile/src/engine/taxEngine.ts
+++ b/cukaipal-mobile/src/engine/taxEngine.ts
@@ -251,7 +251,7 @@ export const getYearConfig = (year: number, profile: UserProfile): CategoryConfi
     sharedPools: [medSharedPool],
     advice: 'Serious diseases. RM1,000 sub-limit for checkup/vaccination.',
     details:
-      'Treatment of serious diseases (AIDS, Parkinson's, Cancer, Renal Failure, Leukemia, Heart Attack, Pulmonary Hypertension, Chronic Liver Disease, Fulminant Viral Hepatitis, Head Trauma with Deficit, Brain Tumor, Major Burns, Major Organ Transplant, Major Amputation of Limbs). Fertility treatment (IUI/IVF). Vaccination expenses (up to RM1,000). Complete medical examination, mental health check-up, and COVID-19 detection tests (up to RM1,000). Child development assessment/training (up to RM4,000 from 2023).',
+      `Treatment of serious diseases (AIDS, Parkinson's, Cancer, Renal Failure, Leukemia, Heart Attack, Pulmonary Hypertension, Chronic Liver Disease, Fulminant Viral Hepatitis, Head Trauma with Deficit, Brain Tumor, Major Burns, Major Organ Transplant, Major Amputation of Limbs). Fertility treatment (IUI/IVF). Vaccination expenses (up to RM1,000). Complete medical examination, mental health check-up, and COVID-19 detection tests (up to RM1,000). Child development assessment/training (up to RM4,000 from 2023).`,
   });
 
   // Medical (Parents)

--- a/cukaipal-mobile/src/storage/CloudStorageAdapter.ts
+++ b/cukaipal-mobile/src/storage/CloudStorageAdapter.ts
@@ -130,7 +130,7 @@ export class CloudStorageAdapter extends NativeStorageAdapter {
    */
   getSyncStatus() {
     return {
-      isSync ing: this.syncInProgress,
+      isSyncing: this.syncInProgress,
       lastSyncTime: this.lastSyncTime,
     };
   }

--- a/cukaipal-mobile/tsconfig.json
+++ b/cukaipal-mobile/tsconfig.json
@@ -1,6 +1,19 @@
 {
-  "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
-  }
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-native",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext"
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- replace problematic medical details string with a safe template literal
- fix sync status property name in CloudStorageAdapter
- provide explicit TypeScript compiler options instead of missing Expo base config

## Testing
- npx tsc --noEmit *(fails: missing type definitions due to unavailable dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a4fc10b08321abdd0312ac84e3f5)